### PR TITLE
add additional query parameters to endpoint docs

### DIFF
--- a/app/views/pages/_docs_courses.html.erb
+++ b/app/views/pages/_docs_courses.html.erb
@@ -151,6 +151,31 @@
         </ul>
       </td>
     </tr>
+    <tr>
+      <td><code>per_page</code></td>
+      <td>String</td>
+      <td>Specify how many entries should be returned in a single query, default is 25.</td>
+      <td>
+        <ul>
+          <li>
+            <code>100</code>
+          </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td><code>page</code></td>
+      <td>String</td>
+      <td>Specify which page to return of the paginated results, default is 1.</td>
+      <td>
+        <ul>
+          <li>
+            <code>Spanish IV</code>
+            <code>5</code>
+          </li>
+        </ul>
+      </td>
+    </tr>
     </tbody>
   </table>
 </div>

--- a/app/views/pages/_docs_instructors.html.erb
+++ b/app/views/pages/_docs_instructors.html.erb
@@ -21,13 +21,34 @@
       <td>
         <ul>
           <li>
-            <code>cs 252</code>
+            <code>Peter</code>
           </li>
           <li>
-            <code>Calculus</code>
+            <code>Peter Peterson</code>
           </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td><code>per_page</code></td>
+      <td>String</td>
+      <td>Specify how many entries should be returned in a single query, default is 25.</td>
+      <td>
+        <ul>
           <li>
-            <code>Spanish IV</code>
+            <code>100</code>
+          </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td><code>page</code></td>
+      <td>String</td>
+      <td>Specify which page to return of the paginated results, default is 1.</td>
+      <td>
+        <ul>
+          <li>
+            <code>5</code>
           </li>
         </ul>
       </td>


### PR DESCRIPTION
Makes the documentation for the /v1/instructors endpoint more extensive by filling out more of the accepted parameters.